### PR TITLE
Fix serialization crash

### DIFF
--- a/entity_gym/serialization/msgpack_ragged.py
+++ b/entity_gym/serialization/msgpack_ragged.py
@@ -55,9 +55,9 @@ def ragged_buffer_decode(obj: Any) -> Any:
 
             if dtype == np.float32:
                 return RaggedBufferF32.from_flattened(flattened, lengths)
-            elif dtype == int:
+            elif dtype == int or dtype == np.int64:
                 return RaggedBufferI64.from_flattened(flattened, lengths)
-            elif dtype == bool:
+            elif dtype == bool or dtype == np.bool8:
                 return RaggedBufferBool.from_flattened(flattened, lengths)
             else:
                 raise ValueError(f"Unsupported RaggedBuffer dtype: {dtype}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "entity-gym"
-version = "0.1.9"
+version = "0.1.10"
 description = "Entity Gym"
 authors = ["Clemens Winter <clemenswinter1@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Attempts to fix this crash:

```
I:\PycharmProjects\treasure_hunt\venv\Scripts\python.exe I:\PycharmProjects\treasure_hunt\train.py 
Traceback (most recent call last):
  File "I:\PycharmProjects\treasure_hunt\train.py", line 10, in <module>
    main()
  File "I:\Programs\Python\Python38\lib\site-packages\hyperstate\command.py", line 120, in _f
    return f(sm)
  File "I:\PycharmProjects\treasure_hunt\train.py", line 7, in main
    train(state_manager=state_manager, env=TreasureHunt)
  File "I:\Programs\Python\Python38\lib\site-packages\enn_trainer\train.py", line 390, in train
    next_obs, next_done, metrics = rollout.run(
  File "I:\Programs\Python\Python38\lib\site-packages\enn_trainer\rollout.py", line 83, in run
    next_obs = self.envs.reset(self.obs_space)
  File "I:\Programs\Python\Python38\lib\site-packages\entity_gym\env\add_metrics_wrapper.py", line 33, in reset
    return self.track_metrics(self.env.reset(obs_config))
  File "I:\Programs\Python\Python38\lib\site-packages\entity_gym\env\parallel_env_list.py", line 161, in reset
    remote_obs_batch = remote.recv()
  File "I:\Programs\Python\Python38\lib\site-packages\entity_gym\env\parallel_env_list.py", line 55, in recv
    return msgpack_numpy.loads(
  File "I:\Programs\Python\Python38\lib\site-packages\msgpack_numpy.py", line 287, in unpackb
    return _unpackb(packed, **kwargs)
  File "msgpack_unpacker.pyx", line 194, in msgpack._cmsgpack.unpackb
  File "I:\Programs\Python\Python38\lib\site-packages\msgpack_numpy.py", line 113, in decode
    return obj if chain is None else chain(obj)
  File "I:\Programs\Python\Python38\lib\site-packages\entity_gym\serialization\msgpack_ragged.py", line 63, in ragged_buffer_decode
    raise ValueError(f"Unsupported RaggedBuffer dtype: {dtype}")
ValueError: Unsupported RaggedBuffer dtype: int64

Process finished with exit code 1
```
